### PR TITLE
Add endpoints for ancillary equipment model listing

### DIFF
--- a/tecrep-equipments-management-domain/src/main/java/mc/monacotelecom/tecrep/equipments/repository/EquipmentModelRepository.java
+++ b/tecrep-equipments-management-domain/src/main/java/mc/monacotelecom/tecrep/equipments/repository/EquipmentModelRepository.java
@@ -1,9 +1,12 @@
 package mc.monacotelecom.tecrep.equipments.repository;
 
 import mc.monacotelecom.tecrep.equipments.entity.EquipmentModel;
+import mc.monacotelecom.tecrep.equipments.enums.AccessType;
 import mc.monacotelecom.tecrep.equipments.enums.EquipmentModelCategory;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.data.repository.history.RevisionRepository;
 
 import java.util.Optional;
@@ -11,5 +14,12 @@ import java.util.Optional;
 public interface EquipmentModelRepository extends JpaRepository<EquipmentModel, Long>, JpaSpecificationExecutor<EquipmentModel>, RevisionRepository<EquipmentModel, Long, Integer> {
     boolean existsByNameAndCategory(final String modelName, final EquipmentModelCategory category);
     Optional<EquipmentModel> findByNameAndCategory(final String modelName, final EquipmentModelCategory category);
-     Optional<EquipmentModel> findByName(String name);
+    Optional<EquipmentModel> findByName(String name);
+
+    @Query("SELECT DISTINCT e.accessType FROM EquipmentModel e WHERE e.category = :category")
+    List<AccessType> findDistinctAccessTypesByCategory(@Param("category") EquipmentModelCategory category);
+
+    @Query("SELECT e.name FROM EquipmentModel e WHERE e.category = :category AND e.accessType = :accessType")
+    List<String> findNamesByCategoryAndAccessType(@Param("category") EquipmentModelCategory category,
+                                                  @Param("accessType") AccessType accessType);
 }

--- a/tecrep-equipments-management-process/src/main/java/mc/monacotelecom/tecrep/equipments/process/EquipmentModelProcess.java
+++ b/tecrep-equipments-management-process/src/main/java/mc/monacotelecom/tecrep/equipments/process/EquipmentModelProcess.java
@@ -10,6 +10,7 @@ import mc.monacotelecom.tecrep.equipments.dto.request.search.SearchEquipmentMode
 import mc.monacotelecom.tecrep.equipments.dto.v2.EquipmentModelDTOV2;
 import mc.monacotelecom.tecrep.equipments.entity.EquipmentModel;
 import mc.monacotelecom.tecrep.equipments.entity.Provider;
+import mc.monacotelecom.tecrep.equipments.enums.AccessType;
 import mc.monacotelecom.tecrep.equipments.enums.EquipmentModelCategory;
 import mc.monacotelecom.tecrep.equipments.exceptions.EqmConflictException;
 import mc.monacotelecom.tecrep.equipments.exceptions.EqmNotFoundException;
@@ -24,6 +25,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.domain.Specification;
 import org.springframework.stereotype.Component;
 
+import java.util.List;
 import java.util.Objects;
 
 import static mc.monacotelecom.tecrep.equipments.translation.TranslationMessages.*;
@@ -150,5 +152,15 @@ public class EquipmentModelProcess implements IEquipmentModelProcess {
         }
 
         equipmentModelRepository.delete(equipmentModel);
+    }
+
+    @Override
+    public List<AccessType> getAccessTypesByCategory(final EquipmentModelCategory category) {
+        return equipmentModelRepository.findDistinctAccessTypesByCategory(category);
+    }
+
+    @Override
+    public List<String> getNamesByCategoryAndAccessType(final EquipmentModelCategory category, final AccessType accessType) {
+        return equipmentModelRepository.findNamesByCategoryAndAccessType(category, accessType);
     }
 }

--- a/tecrep-equipments-management-process/src/main/java/mc/monacotelecom/tecrep/equipments/process/IEquipmentModelProcess.java
+++ b/tecrep-equipments-management-process/src/main/java/mc/monacotelecom/tecrep/equipments/process/IEquipmentModelProcess.java
@@ -5,7 +5,9 @@ import mc.monacotelecom.tecrep.equipments.dto.request.EquipmentModelCreateDTO;
 import mc.monacotelecom.tecrep.equipments.dto.request.search.SearchEquipmentModelDTO;
 import mc.monacotelecom.tecrep.equipments.dto.v2.EquipmentModelDTOV2;
 import mc.monacotelecom.tecrep.equipments.entity.EquipmentModel;
+import mc.monacotelecom.tecrep.equipments.enums.AccessType;
 import mc.monacotelecom.tecrep.equipments.enums.EquipmentModelCategory;
+import java.util.List;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
@@ -79,4 +81,21 @@ public interface IEquipmentModelProcess {
     Page<EquipmentModelDTO> getAllV1(Pageable pageable);
 
     Page<EquipmentModelDTOV2> search(SearchEquipmentModelDTO dto, Pageable pageable);
+
+    /**
+     * Get the list of access types for a specific category
+     *
+     * @param category equipment model category
+     * @return list of {@link AccessType}
+     */
+    List<AccessType> getAccessTypesByCategory(EquipmentModelCategory category);
+
+    /**
+     * Get equipment model names for a category and access type
+     *
+     * @param category    equipment model category
+     * @param accessType  equipment model access type
+     * @return list of model names
+     */
+    List<String> getNamesByCategoryAndAccessType(EquipmentModelCategory category, AccessType accessType);
 }

--- a/tecrep-equipments-management-service/src/main/java/mc/monacotelecom/tecrep/equipments/service/EquipmentModelService.java
+++ b/tecrep-equipments-management-service/src/main/java/mc/monacotelecom/tecrep/equipments/service/EquipmentModelService.java
@@ -5,7 +5,10 @@ import mc.monacotelecom.tecrep.equipments.dto.EquipmentModelDTO;
 import mc.monacotelecom.tecrep.equipments.dto.request.EquipmentModelCreateDTO;
 import mc.monacotelecom.tecrep.equipments.dto.request.search.SearchEquipmentModelDTO;
 import mc.monacotelecom.tecrep.equipments.dto.v2.EquipmentModelDTOV2;
+import mc.monacotelecom.tecrep.equipments.enums.AccessType;
+import mc.monacotelecom.tecrep.equipments.enums.EquipmentModelCategory;
 import mc.monacotelecom.tecrep.equipments.process.EquipmentModelProcess;
+import java.util.List;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
@@ -60,6 +63,16 @@ public class EquipmentModelService {
     @Transactional(readOnly = true)
     public Page<EquipmentModelDTOV2> search(final SearchEquipmentModelDTO dto, final Pageable pageable) {
         return equipmentModelProcess.search(dto, pageable);
+    }
+
+    @Transactional(readOnly = true)
+    public List<AccessType> getAccessTypesByCategory(final EquipmentModelCategory category) {
+        return equipmentModelProcess.getAccessTypesByCategory(category);
+    }
+
+    @Transactional(readOnly = true)
+    public List<String> getNamesByCategoryAndAccessType(final EquipmentModelCategory category, final AccessType accessType) {
+        return equipmentModelProcess.getNamesByCategoryAndAccessType(category, accessType);
     }
 
     @Transactional

--- a/tecrep-equipments-management-webservice/src/main/java/mc/monacotelecom/tecrep/equipments/controller/EquipmentModelControllerV2.java
+++ b/tecrep-equipments-management-webservice/src/main/java/mc/monacotelecom/tecrep/equipments/controller/EquipmentModelControllerV2.java
@@ -8,7 +8,10 @@ import lombok.AllArgsConstructor;
 import mc.monacotelecom.tecrep.equipments.dto.request.EquipmentModelCreateDTO;
 import mc.monacotelecom.tecrep.equipments.dto.request.search.SearchEquipmentModelDTO;
 import mc.monacotelecom.tecrep.equipments.dto.v2.EquipmentModelDTOV2;
+import mc.monacotelecom.tecrep.equipments.enums.AccessType;
+import mc.monacotelecom.tecrep.equipments.enums.EquipmentModelCategory;
 import mc.monacotelecom.tecrep.equipments.service.EquipmentModelService;
+import java.util.List;
 import org.springdoc.core.converters.models.PageableAsQueryParam;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -72,5 +75,20 @@ public class EquipmentModelControllerV2 {
     @ResponseStatus(HttpStatus.NO_CONTENT)
     public void delete(@PathVariable final long id) {
         equipmentModelService.delete(id);
+    }
+
+    @Operation(summary = "Get access types for a category")
+    @ApiResponse(responseCode = "200", description = "Access types retrieved")
+    @GetMapping("/access-types")
+    public List<AccessType> getAccessTypes(@RequestParam EquipmentModelCategory category) {
+        return equipmentModelService.getAccessTypesByCategory(category);
+    }
+
+    @Operation(summary = "Get equipment model names by category and access type")
+    @ApiResponse(responseCode = "200", description = "Names retrieved")
+    @GetMapping("/names")
+    public List<String> getNames(@RequestParam EquipmentModelCategory category,
+                                 @RequestParam AccessType accessType) {
+        return equipmentModelService.getNamesByCategoryAndAccessType(category, accessType);
     }
 }


### PR DESCRIPTION
## Summary
- extend EquipmentModelRepository with queries to fetch access types and names
- expose methods in EquipmentModelProcess and service layer
- add REST endpoints in EquipmentModelControllerV2 for listing access types and names

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_68878ca574c88323ae205c138f1b7371