### PR TITLE
Add GET endpoint for HomologacionMaterialSap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # tecrep-equipments-management changelog
 
+## 2.33.0
+* Added endpoint to list all records from homologacion_material_sap table
+
 ## 2.32.0
 * Added endpoint to list all records from po_ancillary_equipment_sap table
 

--- a/tecrep-equipments-management-service/src/main/java/mc/monacotelecom/tecrep/equipments/service/HomologacionMaterialSapService.java
+++ b/tecrep-equipments-management-service/src/main/java/mc/monacotelecom/tecrep/equipments/service/HomologacionMaterialSapService.java
@@ -1,0 +1,21 @@
+package mc.monacotelecom.tecrep.equipments.service;
+
+import lombok.RequiredArgsConstructor;
+import mc.monacotelecom.tecrep.equipments.entity.HomologacionMaterialSap;
+import mc.monacotelecom.tecrep.equipments.repository.HomologacionMaterialSapRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class HomologacionMaterialSapService {
+
+    private final HomologacionMaterialSapRepository repository;
+
+    @Transactional(readOnly = true)
+    public List<HomologacionMaterialSap> getAll() {
+        return repository.findAll();
+    }
+}

--- a/tecrep-equipments-management-webservice/src/main/java/mc/monacotelecom/tecrep/equipments/controller/HomologacionMaterialSapController.java
+++ b/tecrep-equipments-management-webservice/src/main/java/mc/monacotelecom/tecrep/equipments/controller/HomologacionMaterialSapController.java
@@ -1,0 +1,29 @@
+package mc.monacotelecom.tecrep.equipments.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import mc.monacotelecom.tecrep.equipments.entity.HomologacionMaterialSap;
+import mc.monacotelecom.tecrep.equipments.service.HomologacionMaterialSapService;
+import org.springframework.web.bind.annotation.CrossOrigin;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@Tag(name = "Homologacion Material SAP API")
+@CrossOrigin
+@RestController
+@RequestMapping("api/v2/private/auth/homologacionMaterialSap")
+@RequiredArgsConstructor
+public class HomologacionMaterialSapController {
+
+    private final HomologacionMaterialSapService service;
+
+    @Operation(summary = "Get all homologacion material records")
+    @GetMapping
+    public List<HomologacionMaterialSap> getAll() {
+        return service.getAll();
+    }
+}


### PR DESCRIPTION
## Summary
- add service layer for HomologacionMaterialSap
- expose controller to fetch all homologacion_material_sap
- document new endpoint in changelog

## Testing
- `mvn -q test -pl tecrep-equipments-management-webservice -am` *(fails: Could not resolve parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_68879f12c9a88323a875efd4a41820cb