### PR TITLE
Return id in equipment model names endpoint

### DIFF
--- a/tecrep-equipments-management-domain/src/main/java/mc/monacotelecom/tecrep/equipments/projections/EquipmentModelNameProjection.java
+++ b/tecrep-equipments-management-domain/src/main/java/mc/monacotelecom/tecrep/equipments/projections/EquipmentModelNameProjection.java
@@ -1,0 +1,6 @@
+package mc.monacotelecom.tecrep.equipments.projections;
+
+public interface EquipmentModelNameProjection {
+    Long getId();
+    String getName();
+}

--- a/tecrep-equipments-management-domain/src/main/java/mc/monacotelecom/tecrep/equipments/repository/EquipmentModelRepository.java
+++ b/tecrep-equipments-management-domain/src/main/java/mc/monacotelecom/tecrep/equipments/repository/EquipmentModelRepository.java
@@ -3,12 +3,14 @@ package mc.monacotelecom.tecrep.equipments.repository;
 import mc.monacotelecom.tecrep.equipments.entity.EquipmentModel;
 import mc.monacotelecom.tecrep.equipments.enums.AccessType;
 import mc.monacotelecom.tecrep.equipments.enums.EquipmentModelCategory;
+import mc.monacotelecom.tecrep.equipments.projections.EquipmentModelNameProjection;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.data.repository.history.RevisionRepository;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface EquipmentModelRepository extends JpaRepository<EquipmentModel, Long>, JpaSpecificationExecutor<EquipmentModel>, RevisionRepository<EquipmentModel, Long, Integer> {
@@ -22,4 +24,8 @@ public interface EquipmentModelRepository extends JpaRepository<EquipmentModel, 
     @Query("SELECT e.name FROM EquipmentModel e WHERE e.category = :category AND e.accessType = :accessType")
     List<String> findNamesByCategoryAndAccessType(@Param("category") EquipmentModelCategory category,
                                                   @Param("accessType") AccessType accessType);
+
+    @Query("SELECT e.id AS id, e.name AS name FROM EquipmentModel e WHERE e.category = :category AND e.accessType = :accessType ORDER BY e.id")
+    List<EquipmentModelNameProjection> findIdAndNameByCategoryAndAccessType(@Param("category") EquipmentModelCategory category,
+                                                                            @Param("accessType") AccessType accessType);
 }

--- a/tecrep-equipments-management-dto/src/main/java/mc/monacotelecom/tecrep/equipments/dto/v2/EquipmentModelNameDTOV2.java
+++ b/tecrep-equipments-management-dto/src/main/java/mc/monacotelecom/tecrep/equipments/dto/v2/EquipmentModelNameDTOV2.java
@@ -1,0 +1,19 @@
+package mc.monacotelecom.tecrep.equipments.dto.v2;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class EquipmentModelNameDTOV2 {
+    @Schema(description = "Internal ID", example = "1")
+    private long id;
+
+    @Schema(description = "Name", example = "FAST5670")
+    private String name;
+}

--- a/tecrep-equipments-management-process/src/main/java/mc/monacotelecom/tecrep/equipments/process/EquipmentModelProcess.java
+++ b/tecrep-equipments-management-process/src/main/java/mc/monacotelecom/tecrep/equipments/process/EquipmentModelProcess.java
@@ -8,6 +8,7 @@ import mc.monacotelecom.tecrep.equipments.dto.EquipmentModelDTO;
 import mc.monacotelecom.tecrep.equipments.dto.request.EquipmentModelCreateDTO;
 import mc.monacotelecom.tecrep.equipments.dto.request.search.SearchEquipmentModelDTO;
 import mc.monacotelecom.tecrep.equipments.dto.v2.EquipmentModelDTOV2;
+import mc.monacotelecom.tecrep.equipments.dto.v2.EquipmentModelNameDTOV2;
 import mc.monacotelecom.tecrep.equipments.entity.EquipmentModel;
 import mc.monacotelecom.tecrep.equipments.entity.Provider;
 import mc.monacotelecom.tecrep.equipments.enums.AccessType;
@@ -160,7 +161,10 @@ public class EquipmentModelProcess implements IEquipmentModelProcess {
     }
 
     @Override
-    public List<String> getNamesByCategoryAndAccessType(final EquipmentModelCategory category, final AccessType accessType) {
-        return equipmentModelRepository.findNamesByCategoryAndAccessType(category, accessType);
+    public List<EquipmentModelNameDTOV2> getNamesByCategoryAndAccessType(final EquipmentModelCategory category, final AccessType accessType) {
+        return equipmentModelRepository.findIdAndNameByCategoryAndAccessType(category, accessType)
+                .stream()
+                .map(p -> new EquipmentModelNameDTOV2(p.getId(), p.getName()))
+                .collect(java.util.stream.Collectors.toList());
     }
 }

--- a/tecrep-equipments-management-process/src/main/java/mc/monacotelecom/tecrep/equipments/process/IEquipmentModelProcess.java
+++ b/tecrep-equipments-management-process/src/main/java/mc/monacotelecom/tecrep/equipments/process/IEquipmentModelProcess.java
@@ -4,6 +4,7 @@ import mc.monacotelecom.tecrep.equipments.dto.EquipmentModelDTO;
 import mc.monacotelecom.tecrep.equipments.dto.request.EquipmentModelCreateDTO;
 import mc.monacotelecom.tecrep.equipments.dto.request.search.SearchEquipmentModelDTO;
 import mc.monacotelecom.tecrep.equipments.dto.v2.EquipmentModelDTOV2;
+import mc.monacotelecom.tecrep.equipments.dto.v2.EquipmentModelNameDTOV2;
 import mc.monacotelecom.tecrep.equipments.entity.EquipmentModel;
 import mc.monacotelecom.tecrep.equipments.enums.AccessType;
 import mc.monacotelecom.tecrep.equipments.enums.EquipmentModelCategory;
@@ -95,7 +96,7 @@ public interface IEquipmentModelProcess {
      *
      * @param category    equipment model category
      * @param accessType  equipment model access type
-     * @return list of model names
+     * @return list of model ids and names
      */
-    List<String> getNamesByCategoryAndAccessType(EquipmentModelCategory category, AccessType accessType);
+    List<EquipmentModelNameDTOV2> getNamesByCategoryAndAccessType(EquipmentModelCategory category, AccessType accessType);
 }

--- a/tecrep-equipments-management-service/src/main/java/mc/monacotelecom/tecrep/equipments/service/EquipmentModelService.java
+++ b/tecrep-equipments-management-service/src/main/java/mc/monacotelecom/tecrep/equipments/service/EquipmentModelService.java
@@ -5,6 +5,7 @@ import mc.monacotelecom.tecrep.equipments.dto.EquipmentModelDTO;
 import mc.monacotelecom.tecrep.equipments.dto.request.EquipmentModelCreateDTO;
 import mc.monacotelecom.tecrep.equipments.dto.request.search.SearchEquipmentModelDTO;
 import mc.monacotelecom.tecrep.equipments.dto.v2.EquipmentModelDTOV2;
+import mc.monacotelecom.tecrep.equipments.dto.v2.EquipmentModelNameDTOV2;
 import mc.monacotelecom.tecrep.equipments.enums.AccessType;
 import mc.monacotelecom.tecrep.equipments.enums.EquipmentModelCategory;
 import mc.monacotelecom.tecrep.equipments.process.EquipmentModelProcess;
@@ -71,7 +72,7 @@ public class EquipmentModelService {
     }
 
     @Transactional(readOnly = true)
-    public List<String> getNamesByCategoryAndAccessType(final EquipmentModelCategory category, final AccessType accessType) {
+    public List<EquipmentModelNameDTOV2> getNamesByCategoryAndAccessType(final EquipmentModelCategory category, final AccessType accessType) {
         return equipmentModelProcess.getNamesByCategoryAndAccessType(category, accessType);
     }
 

--- a/tecrep-equipments-management-webservice/src/main/java/mc/monacotelecom/tecrep/equipments/controller/EquipmentModelControllerV2.java
+++ b/tecrep-equipments-management-webservice/src/main/java/mc/monacotelecom/tecrep/equipments/controller/EquipmentModelControllerV2.java
@@ -8,6 +8,7 @@ import lombok.AllArgsConstructor;
 import mc.monacotelecom.tecrep.equipments.dto.request.EquipmentModelCreateDTO;
 import mc.monacotelecom.tecrep.equipments.dto.request.search.SearchEquipmentModelDTO;
 import mc.monacotelecom.tecrep.equipments.dto.v2.EquipmentModelDTOV2;
+import mc.monacotelecom.tecrep.equipments.dto.v2.EquipmentModelNameDTOV2;
 import mc.monacotelecom.tecrep.equipments.enums.AccessType;
 import mc.monacotelecom.tecrep.equipments.enums.EquipmentModelCategory;
 import mc.monacotelecom.tecrep.equipments.service.EquipmentModelService;
@@ -87,7 +88,7 @@ public class EquipmentModelControllerV2 {
     @Operation(summary = "Get equipment model names by category and access type")
     @ApiResponse(responseCode = "200", description = "Names retrieved")
     @GetMapping("/names")
-    public List<String> getNames(@RequestParam EquipmentModelCategory category,
+    public List<EquipmentModelNameDTOV2> getNames(@RequestParam EquipmentModelCategory category,
                                  @RequestParam AccessType accessType) {
         return equipmentModelService.getNamesByCategoryAndAccessType(category, accessType);
     }

--- a/tecrep-equipments-management-webservice/src/test/java/mc/monacotelecom/tecrep/equipments/integration/EquipmentModelIntegrationV2Test.java
+++ b/tecrep-equipments-management-webservice/src/test/java/mc/monacotelecom/tecrep/equipments/integration/EquipmentModelIntegrationV2Test.java
@@ -210,4 +210,16 @@ class EquipmentModelIntegrationV2Test extends BaseIntegrationTest {
                 .andExpect(jsonPath("$.errorCode").value("Conflict"))
                 .andExpect(jsonPath("$.errorMessage").value("An equipment model with name 'name-1' and category 'CPE' already exists"));
     }
+
+    @Test
+    void getNames_success() throws Exception {
+        mockMvc.perform(get(baseUrl + "/names")
+                        .param("category", "CPE")
+                        .param("accessType", "DOCSIS"))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$", hasSize(4)))
+                .andExpect(jsonPath("$[0].id").value(1))
+                .andExpect(jsonPath("$[0].name").value("name-1"));
+    }
 }


### PR DESCRIPTION
## Summary
- add EquipmentModelNameDTOV2 to carry id and name
- expose projection for id and name in repository
- return list of ids and names for `/names` endpoint
- test new endpoint behaviour

## Testing
- `mvn -pl tecrep-equipments-management-webservice -am test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_6887cabd1e1083238cbdaeb7a6f73f84