### PR TITLE
Extend homologacion GET with equipment model data

### DIFF
--- a/tecrep-equipments-management-dto/src/main/java/mc/monacotelecom/tecrep/equipments/dto/v2/HomologacionMaterialSapDTOV2.java
+++ b/tecrep-equipments-management-dto/src/main/java/mc/monacotelecom/tecrep/equipments/dto/v2/HomologacionMaterialSapDTOV2.java
@@ -1,0 +1,31 @@
+package mc.monacotelecom.tecrep.equipments.dto.v2;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import mc.monacotelecom.tecrep.equipments.enums.AccessType;
+
+@Data
+@NoArgsConstructor
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class HomologacionMaterialSapDTOV2 {
+
+    @Schema(description = "Internal ID", example = "1")
+    private Long id;
+
+    @Schema(description = "Material SAP identifier")
+    private String idMaterialSap;
+
+    @Schema(description = "Material SAP name")
+    private String nameSap;
+
+    @Schema(description = "Related equipment model ID")
+    private Long equipmentModelId;
+
+    @Schema(description = "Related equipment model name")
+    private String equipmentModelName;
+
+    @Schema(description = "Access type of the equipment model")
+    private AccessType accessType;
+}

--- a/tecrep-equipments-management-service/src/main/java/mc/monacotelecom/tecrep/equipments/service/HomologacionMaterialSapService.java
+++ b/tecrep-equipments-management-service/src/main/java/mc/monacotelecom/tecrep/equipments/service/HomologacionMaterialSapService.java
@@ -3,6 +3,8 @@ package mc.monacotelecom.tecrep.equipments.service;
 import lombok.RequiredArgsConstructor;
 import mc.monacotelecom.tecrep.equipments.entity.HomologacionMaterialSap;
 import mc.monacotelecom.tecrep.equipments.repository.HomologacionMaterialSapRepository;
+import mc.monacotelecom.tecrep.equipments.repository.EquipmentModelRepository;
+import mc.monacotelecom.tecrep.equipments.dto.v2.HomologacionMaterialSapDTOV2;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
@@ -14,10 +16,27 @@ import org.springframework.transaction.annotation.Transactional;
 public class HomologacionMaterialSapService {
 
     private final HomologacionMaterialSapRepository repository;
+    private final EquipmentModelRepository equipmentModelRepository;
 
     @Transactional(readOnly = true)
-    public Page<HomologacionMaterialSap> getAll(Pageable pageable) {
-        return repository.findAll(pageable);
+    public Page<HomologacionMaterialSapDTOV2> getAll(Pageable pageable) {
+        return repository.findAll(pageable).map(this::mapToDto);
+    }
+
+    private HomologacionMaterialSapDTOV2 mapToDto(HomologacionMaterialSap entity) {
+        HomologacionMaterialSapDTOV2 dto = new HomologacionMaterialSapDTOV2();
+        dto.setId(entity.getId());
+        dto.setIdMaterialSap(entity.getIdMaterialSap());
+        dto.setNameSap(entity.getNameSap());
+        dto.setEquipmentModelId(entity.getEquipmentModelId());
+        if (entity.getEquipmentModelId() != null) {
+            equipmentModelRepository.findById(entity.getEquipmentModelId())
+                    .ifPresent(model -> {
+                        dto.setEquipmentModelName(model.getName());
+                        dto.setAccessType(model.getAccessType());
+                    });
+        }
+        return dto;
     }
 
     @Transactional

--- a/tecrep-equipments-management-webservice/src/main/java/mc/monacotelecom/tecrep/equipments/controller/HomologacionMaterialSapController.java
+++ b/tecrep-equipments-management-webservice/src/main/java/mc/monacotelecom/tecrep/equipments/controller/HomologacionMaterialSapController.java
@@ -6,6 +6,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import mc.monacotelecom.tecrep.equipments.entity.HomologacionMaterialSap;
 import mc.monacotelecom.tecrep.equipments.service.HomologacionMaterialSapService;
+import mc.monacotelecom.tecrep.equipments.dto.v2.HomologacionMaterialSapDTOV2;
 import org.springdoc.core.converters.models.PageableAsQueryParam;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -25,7 +26,7 @@ public class HomologacionMaterialSapController {
     @Operation(summary = "Get all homologacion material records")
     @PageableAsQueryParam
     @GetMapping
-    public Page<HomologacionMaterialSap> getAll(@Parameter(hidden = true) Pageable pageable) {
+    public Page<HomologacionMaterialSapDTOV2> getAll(@Parameter(hidden = true) Pageable pageable) {
         return service.getAll(pageable);
     }
 


### PR DESCRIPTION
## Summary
- add `HomologacionMaterialSapDTOV2` with equipment model name and access type
- enrich `HomologacionMaterialSapService#getAll` to map model info
- update controller to return the new DTO type

## Testing
- `mvn -q -DskipTests package` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_6888f353110c8323a4b1eca2af8ef5a7