### PR TITLE
Add status to homologacion_material_sap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # tecrep-equipments-management changelog
 
+## 2.34.0
+* Added status column to homologacion_material_sap table and updated related endpoints
+
 ## 2.33.0
 * Added endpoint to list all records from homologacion_material_sap table
 

--- a/tecrep-equipments-management-domain/src/main/java/mc/monacotelecom/tecrep/equipments/entity/HomologacionMaterialSap.java
+++ b/tecrep-equipments-management-domain/src/main/java/mc/monacotelecom/tecrep/equipments/entity/HomologacionMaterialSap.java
@@ -26,4 +26,7 @@ public class HomologacionMaterialSap implements Serializable {
 
     @Column(name = "equipment_model_id")
     private Long equipmentModelId;
+
+    @Column(name = "status")
+    private String status;
 }

--- a/tecrep-equipments-management-dto/src/main/java/mc/monacotelecom/tecrep/equipments/dto/v2/HomologacionMaterialSapDTOV2.java
+++ b/tecrep-equipments-management-dto/src/main/java/mc/monacotelecom/tecrep/equipments/dto/v2/HomologacionMaterialSapDTOV2.java
@@ -23,6 +23,9 @@ public class HomologacionMaterialSapDTOV2 {
     @Schema(description = "Related equipment model ID")
     private Long equipmentModelId;
 
+    @Schema(description = "Status of the material")
+    private String status;
+
     @Schema(description = "Related equipment model name")
     private String equipmentModelName;
 

--- a/tecrep-equipments-management-service/src/main/java/mc/monacotelecom/tecrep/equipments/service/HomologacionMaterialSapService.java
+++ b/tecrep-equipments-management-service/src/main/java/mc/monacotelecom/tecrep/equipments/service/HomologacionMaterialSapService.java
@@ -29,6 +29,7 @@ public class HomologacionMaterialSapService {
         dto.setIdMaterialSap(entity.getIdMaterialSap());
         dto.setNameSap(entity.getNameSap());
         dto.setEquipmentModelId(entity.getEquipmentModelId());
+        dto.setStatus(entity.getStatus());
         if (entity.getEquipmentModelId() != null) {
             equipmentModelRepository.findById(entity.getEquipmentModelId())
                     .ifPresent(model -> {

--- a/tecrep-equipments-management-webservice/src/main/resources/db/changelog/db.changelog-master.xml
+++ b/tecrep-equipments-management-webservice/src/main/resources/db/changelog/db.changelog-master.xml
@@ -32,4 +32,5 @@
     <include file="db/changelog/version/db-changelog-2.29.xml"/>
     <include file="db/changelog/version/db-changelog-2.30.xml"/>
     <include file="db/changelog/version/db-changelog-2.31.xml"/>
+    <include file="db/changelog/version/db-changelog-2.32.xml"/>
 </databaseChangeLog>

--- a/tecrep-equipments-management-webservice/src/main/resources/db/changelog/version/db-changelog-2.32.xml
+++ b/tecrep-equipments-management-webservice/src/main/resources/db/changelog/version/db-changelog-2.32.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                   http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.8.xsd">
+
+    <changeSet author="tecrep" id="add-status-column-homologacion-material-sap">
+        <addColumn tableName="homologacion_material_sap">
+            <column name="status" type="VARCHAR(50)"/>
+        </addColumn>
+    </changeSet>
+
+</databaseChangeLog>


### PR DESCRIPTION
## Summary
- add status field to HomologacionMaterialSap entity
- expose status in DTO and service mapping
- update Liquibase changelog
- document in CHANGELOG

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_688a3ea93c188323ad4919422f66f69e