### PR TITLE
Extend PO ancillary SAP endpoint with modelId

### DIFF
--- a/tecrep-equipments-management-domain/src/main/java/mc/monacotelecom/tecrep/equipments/repository/HomologacionMaterialSapRepository.java
+++ b/tecrep-equipments-management-domain/src/main/java/mc/monacotelecom/tecrep/equipments/repository/HomologacionMaterialSapRepository.java
@@ -2,6 +2,8 @@ package mc.monacotelecom.tecrep.equipments.repository;
 
 import mc.monacotelecom.tecrep.equipments.entity.HomologacionMaterialSap;
 import org.springframework.data.jpa.repository.JpaRepository;
+import java.util.Optional;
 
 public interface HomologacionMaterialSapRepository extends JpaRepository<HomologacionMaterialSap, Long> {
+    Optional<HomologacionMaterialSap> findByIdMaterialSap(String idMaterialSap);
 }

--- a/tecrep-equipments-management-dto/src/main/java/mc/monacotelecom/tecrep/equipments/dto/v2/PoAncillaryEquipmentSapDTOV2.java
+++ b/tecrep-equipments-management-dto/src/main/java/mc/monacotelecom/tecrep/equipments/dto/v2/PoAncillaryEquipmentSapDTOV2.java
@@ -1,0 +1,27 @@
+package mc.monacotelecom.tecrep.equipments.dto.v2;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class PoAncillaryEquipmentSapDTOV2 {
+
+    @Schema(description = "Internal ID", example = "1")
+    private Long id;
+
+    @Schema(description = "PO number")
+    private String poNo;
+
+    @Schema(description = "Node model")
+    private String model;
+
+    @Schema(description = "Status of the PO")
+    private String status;
+
+    @Schema(description = "Related equipment model ID")
+    private Long modelId;
+}

--- a/tecrep-equipments-management-service/src/main/java/mc/monacotelecom/tecrep/equipments/service/PoAncillaryEquipmentSapService.java
+++ b/tecrep-equipments-management-service/src/main/java/mc/monacotelecom/tecrep/equipments/service/PoAncillaryEquipmentSapService.java
@@ -1,21 +1,42 @@
 package mc.monacotelecom.tecrep.equipments.service;
 
 import lombok.RequiredArgsConstructor;
+import mc.monacotelecom.tecrep.equipments.dto.v2.PoAncillaryEquipmentSapDTOV2;
 import mc.monacotelecom.tecrep.equipments.entity.PoAncillaryEquipmentSap;
+import mc.monacotelecom.tecrep.equipments.entity.HomologacionMaterialSap;
 import mc.monacotelecom.tecrep.equipments.repository.PoAncillaryEquipmentSapRepository;
+import mc.monacotelecom.tecrep.equipments.repository.HomologacionMaterialSapRepository;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
 public class PoAncillaryEquipmentSapService {
 
     private final PoAncillaryEquipmentSapRepository repository;
+    private final HomologacionMaterialSapRepository homologacionRepository;
 
     @Transactional(readOnly = true)
-    public List<PoAncillaryEquipmentSap> getAll() {
-        return repository.findAll();
+    public List<PoAncillaryEquipmentSapDTOV2> getAll() {
+        return repository.findAll().stream()
+                .map(this::mapToDto)
+                .collect(Collectors.toList());
+    }
+
+    private PoAncillaryEquipmentSapDTOV2 mapToDto(PoAncillaryEquipmentSap entity) {
+        PoAncillaryEquipmentSapDTOV2 dto = new PoAncillaryEquipmentSapDTOV2();
+        dto.setId(entity.getId());
+        dto.setPoNo(entity.getPoNo());
+        dto.setModel(entity.getModel());
+        dto.setStatus(entity.getStatus());
+        if (entity.getModel() != null) {
+            homologacionRepository.findByIdMaterialSap(entity.getModel())
+                    .map(HomologacionMaterialSap::getEquipmentModelId)
+                    .ifPresent(dto::setModelId);
+        }
+        return dto;
     }
 }

--- a/tecrep-equipments-management-webservice/src/main/java/mc/monacotelecom/tecrep/equipments/controller/PoAncillaryEquipmentSapController.java
+++ b/tecrep-equipments-management-webservice/src/main/java/mc/monacotelecom/tecrep/equipments/controller/PoAncillaryEquipmentSapController.java
@@ -3,7 +3,7 @@ package mc.monacotelecom.tecrep.equipments.controller;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
-import mc.monacotelecom.tecrep.equipments.entity.PoAncillaryEquipmentSap;
+import mc.monacotelecom.tecrep.equipments.dto.v2.PoAncillaryEquipmentSapDTOV2;
 import mc.monacotelecom.tecrep.equipments.service.PoAncillaryEquipmentSapService;
 import org.springframework.web.bind.annotation.CrossOrigin;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -23,7 +23,7 @@ public class PoAncillaryEquipmentSapController {
 
     @Operation(summary = "Get all PO records")
     @GetMapping
-    public List<PoAncillaryEquipmentSap> getAll() {
+    public List<PoAncillaryEquipmentSapDTOV2> getAll() {
         return service.getAll();
     }
 }


### PR DESCRIPTION
## Summary
- add `PoAncillaryEquipmentSapDTOV2` DTO to hold new field
- look up equipment model via `HomologacionMaterialSapRepository`
- expose modelId in `PoAncillaryEquipmentSapService`
- return the DTO from `PoAncillaryEquipmentSapController`
- add repository method `findByIdMaterialSap`

## Testing
- `mvn -q -DskipTests install` *(fails: Non-resolvable parent POM)*
- `mvn -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_688b7825a74c8323b8baf91b1e423f37