### PR TITLE
Insert equipments_temp rows for SAP ancillary import

### DIFF
--- a/tecrep-equipments-management-domain/src/main/java/mc/monacotelecom/tecrep/equipments/entity/EquipmentTemp.java
+++ b/tecrep-equipments-management-domain/src/main/java/mc/monacotelecom/tecrep/equipments/entity/EquipmentTemp.java
@@ -61,5 +61,11 @@ public class EquipmentTemp implements Serializable {
 
     @Column(name = "process_date")
     private LocalDateTime processDate;
+
+    // Explicit setter to avoid compilation issues when Lombok processing is
+    // not available in some build environments
+    public void setPoAncillaryeqmSapId(Long poAncillaryeqmSapId) {
+        this.poAncillaryeqmSapId = poAncillaryeqmSapId;
+    }
     
 }


### PR DESCRIPTION
## Summary
- capture EquipmentTemp and homologacion repos in AncillaryImportService
- when importing SAP_ANCILLARY_TEMP, insert valid rows into equipments_temp
- add explicit setter in EquipmentTemp to avoid build issues
- fail the job with a clear message if CSV rows have missing data or invalid model

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_688bc3412f9c8323a719657170e8f7e6