### PR TITLE
feat: return validation messages and status 422

### DIFF
--- a/tecrep-equipments-management-webservice/src/main/java/mc/monacotelecom/tecrep/equipments/exception/EqmControllerAdviceV1.java
+++ b/tecrep-equipments-management-webservice/src/main/java/mc/monacotelecom/tecrep/equipments/exception/EqmControllerAdviceV1.java
@@ -63,11 +63,11 @@ public class EqmControllerAdviceV1 {
         return error(NOT_FOUND, e, resolveMessage(e, locale));
     }
 
-    @ResponseStatus(BAD_REQUEST)
+    @ResponseStatus(UNPROCESSABLE_ENTITY)
     @ExceptionHandler({EqmValidationException.class, CommonImportValidationException.class, CommonExporterException.class})
-    public CustomErrorResponse handleBadRequestException(Exception e, Locale locale) {
+    public CustomErrorResponse handleUnprocessableEntityException(Exception e, Locale locale) {
         log.debug(EXCEPTION_MESSAGE, e);
-        return error(BAD_REQUEST, e, resolveMessage(e, locale));
+        return error(UNPROCESSABLE_ENTITY, e, resolveMessage(e, locale));
     }
 
     @ResponseStatus(BAD_REQUEST)
@@ -127,7 +127,11 @@ public class EqmControllerAdviceV1 {
             String key = le.getMessageKey();
             Object[] args = le.getArgs();
             log.info("🌍 Traduciendo clave '{}' con args {} y locale {}", key, args, locale);
-            return localizedMessageBuilder.getLocalizedMessage(key, args);
+            String localized = localizedMessageBuilder.getLocalizedMessage(key, args);
+            if ((localized == null || localized.equals(key)) && args != null && args.length > 0 && args[0] != null) {
+                return args[0].toString();
+            }
+            return localized;
         }
         return e.getMessage() != null ? e.getMessage() : "Unknown error";
     }


### PR DESCRIPTION
## Summary
- return HTTP 422 for validation errors
- fall back to supplied message when localization key is missing

## Testing
- `mvn -q -pl tecrep-equipments-management-webservice -am test` *(fails: Non-resolvable parent POM: mc.monacotelecom.buildfwk:parent:pom:5.0.10)*

------
https://chatgpt.com/codex/tasks/task_e_6894b7dc789c83238266cbe9d0b9cf2c