### PR TITLE
feat: return validation messages and status 422

### DIFF
--- a/tecrep-equipments-management-process/src/main/java/mc/monacotelecom/tecrep/equipments/exceptions/EqmValidationException.java
+++ b/tecrep-equipments-management-process/src/main/java/mc/monacotelecom/tecrep/equipments/exceptions/EqmValidationException.java
@@ -2,7 +2,10 @@ package mc.monacotelecom.tecrep.equipments.exceptions;
 
 import mc.monacotelecom.inventory.common.nls.LocalizedException;
 import mc.monacotelecom.inventory.common.nls.LocalizedMessageBuilder;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
 
+@ResponseStatus(HttpStatus.UNPROCESSABLE_ENTITY)
 public class EqmValidationException extends LocalizedException {
     public EqmValidationException(LocalizedMessageBuilder messageBuilder, String messageKey, Object... args) {
         super(messageBuilder, messageKey, args);
@@ -10,5 +13,14 @@ public class EqmValidationException extends LocalizedException {
 
     public EqmValidationException(Throwable e, LocalizedMessageBuilder messageBuilder, String messageKey, Object... args) {
         super(e, messageBuilder, messageKey, args);
+    }
+
+    @Override
+    public String getMessage() {
+        Object[] args = getArgs();
+        if (args != null && args.length > 0 && args[0] != null) {
+            return args[0].toString();
+        }
+        return getMessageKey();
     }
 }

--- a/tecrep-equipments-management-process/src/main/java/mc/monacotelecom/tecrep/equipments/translation/TranslationMessages.java
+++ b/tecrep-equipments-management-process/src/main/java/mc/monacotelecom/tecrep/equipments/translation/TranslationMessages.java
@@ -151,5 +151,7 @@ public final class TranslationMessages {
     public static final String EQUIPMENT_TEMP_COMPLETED_EMAIL_NOT_FOUND = "equipment.temp.completed.email.not.found";
     public static final String WRONG_EQUIPMENT_STATUS = "wrong.equipment.status";
     public static final String IMPORT_DIFFERENT_PO_NO = "import.different.po.number";
+    public static final String IMPORT_NO_INSERTS = "import.no.inserts";
+    public static final String IMPORT_PO_NO_MISSING = "import.po.no.missing";
     public static final String EXPORTER_REQUIRED_SEARCH_PARAM = "inventory.exporter.search.mandatory";
 }

--- a/tecrep-equipments-management-process/src/main/resources/messages_en_US.properties
+++ b/tecrep-equipments-management-process/src/main/resources/messages_en_US.properties
@@ -191,3 +191,5 @@ brand=Brand
 equipment.temp.pending.email.not.found=Pending EquipmentTemp uploaded by ''{0}'' not found
 equipment.temp.completed.email.not.found=Completed EquipmentTemp uploaded by ''{0}'' not found
 import.different.po.number=No puede haber PO_NO diferente
+import.no.inserts=No records were inserted. All were skipped due to duplicates or invalid data.
+import.po.no.missing=PO_NUMBER node is missing in the XML

--- a/tecrep-equipments-management-process/src/main/resources/messages_fr_FR.properties
+++ b/tecrep-equipments-management-process/src/main/resources/messages_fr_FR.properties
@@ -190,3 +190,5 @@ brand=Brand
 equipment.temp.pending.email.not.found=Les équipements temporaires en attente pour l'email '{0}' sont introuvables
 equipment.temp.completed.email.not.found=Les équipements temporaires complétés pour l'email '{0}' sont introuvables
 import.different.po.number=Il ne peut pas y avoir de PO_NO différent
+import.no.inserts=Aucun enregistrement n'a été inséré. Tous ont été ignorés car doublons ou données invalides.
+import.po.no.missing=Le nœud PO_NUMBER est manquant dans le XML

--- a/tecrep-equipments-management-webservice/src/main/java/mc/monacotelecom/tecrep/equipments/controller/AncillaryControllerV2.java
+++ b/tecrep-equipments-management-webservice/src/main/java/mc/monacotelecom/tecrep/equipments/controller/AncillaryControllerV2.java
@@ -156,6 +156,7 @@ public class AncillaryControllerV2 {
     @Operation(summary = "Inicia import Ancillary Equipment (asíncrono)")
     @ApiResponse(responseCode = "202", description = "Import process started, devuelve jobId")
     @ApiResponse(responseCode = "400", description = "Invalid file or format")
+    @ApiResponse(responseCode = "422", description = "Validation failed (unprocessable entity)")
     @ApiResponse(responseCode = "500", description = "Internal error")
     @PostMapping(
         path = "/import",

--- a/tecrep-equipments-management-webservice/src/main/java/mc/monacotelecom/tecrep/equipments/exception/EqmControllerAdviceV1.java
+++ b/tecrep-equipments-management-webservice/src/main/java/mc/monacotelecom/tecrep/equipments/exception/EqmControllerAdviceV1.java
@@ -63,11 +63,11 @@ public class EqmControllerAdviceV1 {
         return error(NOT_FOUND, e, resolveMessage(e, locale));
     }
 
-    @ResponseStatus(BAD_REQUEST)
+    @ResponseStatus(UNPROCESSABLE_ENTITY)
     @ExceptionHandler({EqmValidationException.class, CommonImportValidationException.class, CommonExporterException.class})
-    public CustomErrorResponse handleBadRequestException(Exception e, Locale locale) {
+    public CustomErrorResponse handleUnprocessableEntityException(Exception e, Locale locale) {
         log.debug(EXCEPTION_MESSAGE, e);
-        return error(BAD_REQUEST, e, resolveMessage(e, locale));
+        return error(UNPROCESSABLE_ENTITY, e, resolveMessage(e, locale));
     }
 
     @ResponseStatus(BAD_REQUEST)
@@ -127,7 +127,11 @@ public class EqmControllerAdviceV1 {
             String key = le.getMessageKey();
             Object[] args = le.getArgs();
             log.info("🌍 Traduciendo clave '{}' con args {} y locale {}", key, args, locale);
-            return localizedMessageBuilder.getLocalizedMessage(key, args);
+            String localized = localizedMessageBuilder.getLocalizedMessage(key, args);
+            if ((localized == null || localized.equals(key)) && args != null && args.length > 0 && args[0] != null) {
+                return args[0].toString();
+            }
+            return localized;
         }
         return e.getMessage() != null ? e.getMessage() : "Unknown error";
     }


### PR DESCRIPTION
## Summary
- return HTTP 422 for validation errors
- fall back to supplied message when localization key is missing
- provide translations for missing import errors
- ensure EqmValidationException yields 422 status and human-readable messages
- document validation failure (422) response for import endpoint

## Testing
- `mvn -q -pl tecrep-equipments-management-webservice -am test` *(fails: Non-resolvable parent POM: mc.monacotelecom.buildfwk:parent:pom:5.0.10)*

------
https://chatgpt.com/codex/tasks/task_e_6894b7dc789c83238266cbe9d0b9cf2c