### PR TITLE
Log username from security token

### DIFF
--- a/tecrep-equipments-management-webservice/src/main/java/mc/monacotelecom/tecrep/equipments/logs/GlobalExceptionHandler.java
+++ b/tecrep-equipments-management-webservice/src/main/java/mc/monacotelecom/tecrep/equipments/logs/GlobalExceptionHandler.java
@@ -7,6 +7,8 @@ import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
+import static mc.monacotelecom.tecrep.equipments.logs.LogUtils.getUserName;
+
 import javax.servlet.http.HttpServletRequest;
 
 @RestControllerAdvice
@@ -33,6 +35,7 @@ public class GlobalExceptionHandler {
 
         MDC.put("processName", processName);
         MDC.put("uti", uti);
+        MDC.put("user", getUserName());
 
         String errorMsg = ex.getBindingResult().getAllErrors().stream()
                 .map(e -> e.getDefaultMessage())

--- a/tecrep-equipments-management-webservice/src/main/java/mc/monacotelecom/tecrep/equipments/logs/IncomingRequestsLogger.java
+++ b/tecrep-equipments-management-webservice/src/main/java/mc/monacotelecom/tecrep/equipments/logs/IncomingRequestsLogger.java
@@ -11,6 +11,8 @@ import org.aspectj.lang.annotation.Aspect;
 import org.springframework.context.annotation.Configuration;
 import org.slf4j.MDC;
 
+import static mc.monacotelecom.tecrep.equipments.logs.LogUtils.getUserName;
+
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import java.util.Arrays;
@@ -47,6 +49,7 @@ public class IncomingRequestsLogger {
 
         MDC.put("processName", processName);
         MDC.put("uti", uti);
+        MDC.put("user", getUserName());
 
         long startTime = System.currentTimeMillis();
 

--- a/tecrep-equipments-management-webservice/src/main/java/mc/monacotelecom/tecrep/equipments/logs/LogUtils.java
+++ b/tecrep-equipments-management-webservice/src/main/java/mc/monacotelecom/tecrep/equipments/logs/LogUtils.java
@@ -1,0 +1,39 @@
+package mc.monacotelecom.tecrep.equipments.logs;
+
+import org.keycloak.KeycloakPrincipal;
+import org.keycloak.representations.AccessToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+/**
+ * Utility class for logging related helpers.
+ */
+public final class LogUtils {
+
+    private LogUtils() {
+    }
+
+    /**
+     * Extracts the user name from the current security context.
+     *
+     * @return the user name if available, otherwise "N/A".
+     */
+    public static String getUserName() {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        if (authentication != null) {
+            Object principal = authentication.getPrincipal();
+            if (principal instanceof KeycloakPrincipal<?>) {
+                AccessToken token = ((KeycloakPrincipal<?>) principal)
+                        .getKeycloakSecurityContext().getToken();
+                if (token != null && token.getName() != null && !token.getName().isBlank()) {
+                    return token.getName();
+                }
+            }
+            String name = authentication.getName();
+            if (name != null && !name.isBlank()) {
+                return name;
+            }
+        }
+        return "N/A";
+    }
+}

--- a/tecrep-equipments-management-webservice/src/main/java/mc/monacotelecom/tecrep/equipments/logs/RequestLoggingFilter.java
+++ b/tecrep-equipments-management-webservice/src/main/java/mc/monacotelecom/tecrep/equipments/logs/RequestLoggingFilter.java
@@ -5,6 +5,8 @@ import org.slf4j.MDC;
 import org.springframework.stereotype.Component;
 import org.springframework.web.filter.OncePerRequestFilter;
 
+import static mc.monacotelecom.tecrep.equipments.logs.LogUtils.getUserName;
+
 import javax.servlet.FilterChain;
 import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
@@ -41,6 +43,8 @@ public class RequestLoggingFilter extends OncePerRequestFilter {
         try {
             filterChain.doFilter(request, response);
         } finally {
+            MDC.put("user", getUserName());
+
             long duration = System.currentTimeMillis() - startTime;
             int status = response.getStatus();
 

--- a/tecrep-equipments-management-webservice/src/main/resources/logback-spring.xml
+++ b/tecrep-equipments-management-webservice/src/main/resources/logback-spring.xml
@@ -18,7 +18,7 @@
             <!-- Codificación de línea de log -->
             <encoder class="ch.qos.logback.classic.encoder.PatternLayoutEncoder">
               <!--   <Pattern>[%d{yyyy-MM-dd HH:mm:ss}] %X{processName}.%level: processName: %X{processName}, uti: %X{uti}, parameters: %msg%n</Pattern> -->
-                <Pattern>[%d{yyyy-MM-dd HH:mm:ss}] %X{processName}.%level: process: %X{processName}, uti: %X{uti}, parameters: %msg%n</Pattern>
+                <Pattern>[%d{yyyy-MM-dd HH:mm:ss}] %X{processName}.%level: process: %X{processName}, user: %X{user}, uti: %X{uti}, parameters: %msg%n</Pattern>
             </encoder>
 
             <!-- Política de rotación por día y limpieza de archivos > 7 días -->
@@ -36,7 +36,11 @@
     </springProfile>
 
     <springProfile name="!output-logs-as-json">
-        <include resource="org/springframework/boot/logging/logback/console-appender.xml"/>
+        <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+            <encoder class="ch.qos.logback.classic.encoder.PatternLayoutEncoder">
+                <Pattern>[%d{yyyy-MM-dd HH:mm:ss}] %X{processName}.%level: process: %X{processName}, user: %X{user}, uti: %X{uti}, parameters: %msg%n</Pattern>
+            </encoder>
+        </appender>
         <root level="WARN">
             <appender-ref ref="CONSOLE"/>
         </root>
@@ -87,6 +91,9 @@
                                     "remote_host": "%X{req.remoteHost:-}",
                                     "user_agent": "%X{req.userAgent:-}",
                                     "query_string": "%X{req.queryString:-}"
+                                },
+                                "user": {
+                                    "name": "%X{user:-}"
                                 }
                             }
                         </pattern>


### PR DESCRIPTION
## Summary
- capture authenticated user name and place into MDC for request logs
- include user information in log patterns and JSON output
- add helper utility for extracting name from Keycloak tokens
- use custom console appender to expose user info in non-JSON logs

## Testing
- `mvn -q -pl tecrep-equipments-management-webservice -am test` *(fails: Non-resolvable parent POM: mc.monacotelecom.buildfwk:parent:pom:5.0.10)*

------
https://chatgpt.com/codex/tasks/task_e_68a5e74737c48323b7991352d2fd9e80