### PR TITLE
feat: paginate standard load retrieval

### DIFF
--- a/API_ENDPOINTS.md
+++ b/API_ENDPOINTS.md
@@ -431,3 +431,13 @@ Cuando se llama al endpoint `POST /api/v2/private/auth/ancillaryequipments/impor
 
 De este modo, el cliente siempre recibe de inmediato un `jobId`. Luego puede consultar periódicamente `/import/status/{jobId}` para ver el avance, obtener conteos y, cuando finalice, descargar el CSV con el desglose de filas exitosas y errores.  
 
+
+### ⚖️ **5. STANDARD LOADS**
+
+#### **V2** - `/api/v2/private/auth/standard-loads`
+| Método | Endpoint | Descripción |
+|--------|----------|-------------|
+| `GET` | `/` | Listar cargas estándar (paginado) |
+| `GET` | `/{id}` | Obtener carga estándar por ID |
+| `POST` | `/` | Crear carga estándar |
+| `PUT` | `/{id}` | Actualizar carga estándar |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # tecrep-equipments-management changelog
 
+## 2.33.0
+* Added standard_load table and CRUD endpoints
+
 ## 2.31.0
 * Added PGP decryption for SAP_ANCILLARY_TEMP import using Milicom key
 

--- a/tecrep-equipments-management-domain/src/main/java/mc/monacotelecom/tecrep/equipments/entity/StandardLoad.java
+++ b/tecrep-equipments-management-domain/src/main/java/mc/monacotelecom/tecrep/equipments/entity/StandardLoad.java
@@ -1,0 +1,36 @@
+package mc.monacotelecom.tecrep.equipments.entity;
+
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.UpdateTimestamp;
+
+import javax.persistence.*;
+import java.io.Serializable;
+import java.time.LocalDateTime;
+
+@Data
+@NoArgsConstructor
+@Entity
+@Table(name = "standard_load")
+public class StandardLoad implements Serializable {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "name", nullable = false)
+    private String name;
+
+    @CreationTimestamp
+    @Column(name = "creation_date", nullable = false, updatable = false)
+    private LocalDateTime creationDate;
+
+    @UpdateTimestamp
+    @Column(name = "update_date")
+    private LocalDateTime updateDate;
+
+    @Column(name = "status", length = 20)
+    private String status;
+}
+

--- a/tecrep-equipments-management-domain/src/main/java/mc/monacotelecom/tecrep/equipments/repository/StandardLoadRepository.java
+++ b/tecrep-equipments-management-domain/src/main/java/mc/monacotelecom/tecrep/equipments/repository/StandardLoadRepository.java
@@ -1,0 +1,8 @@
+package mc.monacotelecom.tecrep.equipments.repository;
+
+import mc.monacotelecom.tecrep.equipments.entity.StandardLoad;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface StandardLoadRepository extends JpaRepository<StandardLoad, Long> {
+}
+

--- a/tecrep-equipments-management-dto/src/main/java/mc/monacotelecom/tecrep/equipments/dto/v2/StandardLoadDTOV2.java
+++ b/tecrep-equipments-management-dto/src/main/java/mc/monacotelecom/tecrep/equipments/dto/v2/StandardLoadDTOV2.java
@@ -1,0 +1,28 @@
+package mc.monacotelecom.tecrep.equipments.dto.v2;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Data;
+
+import java.time.LocalDateTime;
+
+@Data
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class StandardLoadDTOV2 {
+
+    @Schema(description = "Internal ID", example = "1")
+    private Long id;
+
+    @Schema(description = "Name", example = "Carga estandar")
+    private String name;
+
+    @Schema(description = "Creation date")
+    private LocalDateTime creationDate;
+
+    @Schema(description = "Update date")
+    private LocalDateTime updateDate;
+
+    @Schema(description = "Status", example = "enable")
+    private String status;
+}
+

--- a/tecrep-equipments-management-process/src/main/java/mc/monacotelecom/tecrep/equipments/mapper/StandardLoadMapper.java
+++ b/tecrep-equipments-management-process/src/main/java/mc/monacotelecom/tecrep/equipments/mapper/StandardLoadMapper.java
@@ -1,0 +1,12 @@
+package mc.monacotelecom.tecrep.equipments.mapper;
+
+import mc.monacotelecom.tecrep.equipments.dto.v2.StandardLoadDTOV2;
+import mc.monacotelecom.tecrep.equipments.entity.StandardLoad;
+import org.mapstruct.Mapper;
+
+@Mapper(componentModel = "spring")
+public interface StandardLoadMapper {
+    StandardLoadDTOV2 toDto(StandardLoad entity);
+    StandardLoad toEntity(StandardLoadDTOV2 dto);
+}
+

--- a/tecrep-equipments-management-process/src/main/java/mc/monacotelecom/tecrep/equipments/process/StandardLoadProcess.java
+++ b/tecrep-equipments-management-process/src/main/java/mc/monacotelecom/tecrep/equipments/process/StandardLoadProcess.java
@@ -1,0 +1,48 @@
+package mc.monacotelecom.tecrep.equipments.process;
+
+import lombok.RequiredArgsConstructor;
+import mc.monacotelecom.inventory.common.nls.LocalizedMessageBuilder;
+import mc.monacotelecom.tecrep.equipments.dto.v2.StandardLoadDTOV2;
+import mc.monacotelecom.tecrep.equipments.entity.StandardLoad;
+import mc.monacotelecom.tecrep.equipments.exceptions.EqmNotFoundException;
+import mc.monacotelecom.tecrep.equipments.mapper.StandardLoadMapper;
+import mc.monacotelecom.tecrep.equipments.repository.StandardLoadRepository;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Component;
+
+import static mc.monacotelecom.tecrep.equipments.translation.TranslationMessages.STANDARD_LOAD_ID_NOT_FOUND;
+
+@Component
+@RequiredArgsConstructor
+public class StandardLoadProcess {
+
+    private final StandardLoadRepository standardLoadRepository;
+    private final LocalizedMessageBuilder localizedMessageBuilder;
+    private final StandardLoadMapper standardLoadMapper;
+
+    public StandardLoadDTOV2 getById(Long id) {
+        StandardLoad entity = standardLoadRepository.findById(id)
+                .orElseThrow(() -> new EqmNotFoundException(localizedMessageBuilder, STANDARD_LOAD_ID_NOT_FOUND, id));
+        return standardLoadMapper.toDto(entity);
+    }
+
+    public StandardLoadDTOV2 add(StandardLoadDTOV2 dto) {
+        StandardLoad entity = standardLoadMapper.toEntity(dto);
+        return standardLoadMapper.toDto(standardLoadRepository.save(entity));
+    }
+
+    public StandardLoadDTOV2 update(Long id, StandardLoadDTOV2 dto) {
+        StandardLoad entity = standardLoadRepository.findById(id)
+                .orElseThrow(() -> new EqmNotFoundException(localizedMessageBuilder, STANDARD_LOAD_ID_NOT_FOUND, id));
+        entity.setName(dto.getName());
+        entity.setStatus(dto.getStatus());
+        return standardLoadMapper.toDto(standardLoadRepository.save(entity));
+    }
+
+    public Page<StandardLoadDTOV2> getAll(Pageable pageable) {
+        return standardLoadRepository.findAll(pageable)
+                .map(standardLoadMapper::toDto);
+    }
+}
+

--- a/tecrep-equipments-management-process/src/main/java/mc/monacotelecom/tecrep/equipments/translation/TranslationMessages.java
+++ b/tecrep-equipments-management-process/src/main/java/mc/monacotelecom/tecrep/equipments/translation/TranslationMessages.java
@@ -154,4 +154,5 @@ public final class TranslationMessages {
     public static final String IMPORT_NO_INSERTS = "import.no.inserts";
     public static final String IMPORT_PO_NO_MISSING = "import.po.no.missing";
     public static final String EXPORTER_REQUIRED_SEARCH_PARAM = "inventory.exporter.search.mandatory";
+    public static final String STANDARD_LOAD_ID_NOT_FOUND = "standard.load.id.not.found";
 }

--- a/tecrep-equipments-management-service/src/main/java/mc/monacotelecom/tecrep/equipments/service/StandardLoadService.java
+++ b/tecrep-equipments-management-service/src/main/java/mc/monacotelecom/tecrep/equipments/service/StandardLoadService.java
@@ -1,0 +1,37 @@
+package mc.monacotelecom.tecrep.equipments.service;
+
+import lombok.RequiredArgsConstructor;
+import mc.monacotelecom.tecrep.equipments.dto.v2.StandardLoadDTOV2;
+import mc.monacotelecom.tecrep.equipments.process.StandardLoadProcess;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class StandardLoadService {
+
+    private final StandardLoadProcess standardLoadProcess;
+
+    @Transactional(readOnly = true)
+    public StandardLoadDTOV2 getById(Long id) {
+        return standardLoadProcess.getById(id);
+    }
+
+    @Transactional(readOnly = true)
+    public Page<StandardLoadDTOV2> getAll(Pageable pageable) {
+        return standardLoadProcess.getAll(pageable);
+    }
+
+    @Transactional
+    public StandardLoadDTOV2 add(StandardLoadDTOV2 dto) {
+        return standardLoadProcess.add(dto);
+    }
+
+    @Transactional
+    public StandardLoadDTOV2 update(Long id, StandardLoadDTOV2 dto) {
+        return standardLoadProcess.update(id, dto);
+    }
+}
+

--- a/tecrep-equipments-management-webservice/src/main/java/mc/monacotelecom/tecrep/equipments/controller/StandardLoadController.java
+++ b/tecrep-equipments-management-webservice/src/main/java/mc/monacotelecom/tecrep/equipments/controller/StandardLoadController.java
@@ -1,0 +1,58 @@
+package mc.monacotelecom.tecrep.equipments.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import io.swagger.v3.oas.annotations.Parameter;
+import lombok.RequiredArgsConstructor;
+import mc.monacotelecom.tecrep.equipments.dto.v2.StandardLoadDTOV2;
+import mc.monacotelecom.tecrep.equipments.service.StandardLoadService;
+import org.springdoc.core.annotations.PageableAsQueryParam;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.*;
+
+import javax.validation.Valid;
+
+@Tag(name = "Standard Load API")
+@CrossOrigin
+@RestController
+@RequestMapping("api/v2/private/auth/standard-loads")
+@RequiredArgsConstructor
+public class StandardLoadController {
+
+    private final StandardLoadService standardLoadService;
+
+    @Operation(summary = "Get all standard loads")
+    @ApiResponse(responseCode = "200", description = "Standard loads found")
+    @PageableAsQueryParam
+    @GetMapping
+    public Page<StandardLoadDTOV2> getAll(@Parameter(hidden = true) Pageable pageable) {
+        return standardLoadService.getAll(pageable);
+    }
+
+    @Operation(summary = "Find a standard load by ID")
+    @ApiResponse(responseCode = "200", description = "Standard load found")
+    @ApiResponse(responseCode = "404", description = "Not found")
+    @GetMapping("/{id}")
+    public StandardLoadDTOV2 getById(@PathVariable("id") Long id) {
+        return standardLoadService.getById(id);
+    }
+
+    @Operation(summary = "Add a standard load")
+    @ApiResponse(responseCode = "201", description = "Standard load created")
+    @PostMapping
+    @ResponseStatus(HttpStatus.CREATED)
+    public StandardLoadDTOV2 add(@Valid @RequestBody StandardLoadDTOV2 dto) {
+        return standardLoadService.add(dto);
+    }
+
+    @Operation(summary = "Update a standard load")
+    @ApiResponse(responseCode = "200", description = "Standard load updated")
+    @PutMapping("/{id}")
+    public StandardLoadDTOV2 update(@PathVariable("id") Long id, @Valid @RequestBody StandardLoadDTOV2 dto) {
+        return standardLoadService.update(id, dto);
+    }
+}
+

--- a/tecrep-equipments-management-webservice/src/main/resources/db/changelog/db.changelog-master.xml
+++ b/tecrep-equipments-management-webservice/src/main/resources/db/changelog/db.changelog-master.xml
@@ -33,4 +33,5 @@
     <include file="db/changelog/version/db-changelog-2.30.xml"/>
     <include file="db/changelog/version/db-changelog-2.31.xml"/>
     <include file="db/changelog/version/db-changelog-2.32.xml"/>
+    <include file="db/changelog/version/db-changelog-2.33.xml"/>
 </databaseChangeLog>

--- a/tecrep-equipments-management-webservice/src/main/resources/db/changelog/version/db-changelog-2.33.xml
+++ b/tecrep-equipments-management-webservice/src/main/resources/db/changelog/version/db-changelog-2.33.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                   http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.8.xsd">
+
+    <changeSet author="tecrep" id="create-standard-load">
+        <createTable tableName="standard_load">
+            <column name="id" type="BIGINT" autoIncrement="true">
+                <constraints primaryKey="true" nullable="false"/>
+            </column>
+            <column name="name" type="VARCHAR(255)">
+                <constraints nullable="false"/>
+            </column>
+            <column name="creation_date" type="TIMESTAMP"/>
+            <column name="update_date" type="TIMESTAMP"/>
+            <column name="status" type="VARCHAR(20)"/>
+        </createTable>
+    </changeSet>
+
+</databaseChangeLog>
+


### PR DESCRIPTION
## Summary
- allow listing all standard loads with pagination
- expose pageable GET endpoint under /api/v2/private/auth/standard-loads
- document standard load endpoints

## Testing
- `mvn -q -e -pl tecrep-equipments-management-webservice -am test` *(fails: Non-resolvable parent POM: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a615720a7883238a10423c6b57c97c