### PR TITLE
feat: bulk upsert for standard load items

### DIFF
--- a/tecrep-equipments-management-dto/src/main/java/mc/monacotelecom/tecrep/equipments/annotations/ExactlyOneType.java
+++ b/tecrep-equipments-management-dto/src/main/java/mc/monacotelecom/tecrep/equipments/annotations/ExactlyOneType.java
@@ -1,0 +1,20 @@
+package mc.monacotelecom.tecrep.equipments.annotations;
+
+import javax.validation.Constraint;
+import javax.validation.Payload;
+import java.lang.annotation.Documented;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.TYPE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+@Documented
+@Target(TYPE)
+@Retention(RUNTIME)
+@Constraint(validatedBy = ExactlyOneTypeValidator.class)
+public @interface ExactlyOneType {
+    String message() default "Exactly one of idModel, idMaterial or idGroup must be provided";
+    Class<?>[] groups() default {};
+    Class<? extends Payload>[] payload() default {};
+}

--- a/tecrep-equipments-management-dto/src/main/java/mc/monacotelecom/tecrep/equipments/annotations/ExactlyOneTypeValidator.java
+++ b/tecrep-equipments-management-dto/src/main/java/mc/monacotelecom/tecrep/equipments/annotations/ExactlyOneTypeValidator.java
@@ -1,0 +1,27 @@
+package mc.monacotelecom.tecrep.equipments.annotations;
+
+import mc.monacotelecom.tecrep.equipments.dto.StandardLoadItemDTO;
+
+import javax.validation.ConstraintValidator;
+import javax.validation.ConstraintValidatorContext;
+
+public class ExactlyOneTypeValidator implements ConstraintValidator<ExactlyOneType, StandardLoadItemDTO> {
+
+    @Override
+    public boolean isValid(StandardLoadItemDTO value, ConstraintValidatorContext context) {
+        if (value == null) {
+            return true;
+        }
+        int count = 0;
+        if (value.getIdModel() != null) {
+            count++;
+        }
+        if (value.getIdMaterial() != null) {
+            count++;
+        }
+        if (value.getIdGroup() != null) {
+            count++;
+        }
+        return count == 1;
+    }
+}

--- a/tecrep-equipments-management-dto/src/main/java/mc/monacotelecom/tecrep/equipments/dto/BulkItemResult.java
+++ b/tecrep-equipments-management-dto/src/main/java/mc/monacotelecom/tecrep/equipments/dto/BulkItemResult.java
@@ -1,0 +1,18 @@
+package mc.monacotelecom.tecrep.equipments.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.Map;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class BulkItemResult {
+    private int index;
+    private String target;
+    private Map<String, Long> key;
+    private String status;
+    private String message;
+}

--- a/tecrep-equipments-management-dto/src/main/java/mc/monacotelecom/tecrep/equipments/dto/BulkResultSummary.java
+++ b/tecrep-equipments-management-dto/src/main/java/mc/monacotelecom/tecrep/equipments/dto/BulkResultSummary.java
@@ -1,0 +1,15 @@
+package mc.monacotelecom.tecrep.equipments.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class BulkResultSummary {
+    private int inserted;
+    private int updated;
+    private int skipped;
+    private int validationErrors;
+}

--- a/tecrep-equipments-management-dto/src/main/java/mc/monacotelecom/tecrep/equipments/dto/BulkStandardLoadItemsRequest.java
+++ b/tecrep-equipments-management-dto/src/main/java/mc/monacotelecom/tecrep/equipments/dto/BulkStandardLoadItemsRequest.java
@@ -1,0 +1,15 @@
+package mc.monacotelecom.tecrep.equipments.dto;
+
+import lombok.Data;
+
+import javax.validation.Valid;
+import javax.validation.constraints.NotNull;
+import java.util.List;
+
+@Data
+public class BulkStandardLoadItemsRequest {
+
+    @NotNull
+    @Valid
+    private List<StandardLoadItemDTO> items;
+}

--- a/tecrep-equipments-management-dto/src/main/java/mc/monacotelecom/tecrep/equipments/dto/BulkStandardLoadItemsResponse.java
+++ b/tecrep-equipments-management-dto/src/main/java/mc/monacotelecom/tecrep/equipments/dto/BulkStandardLoadItemsResponse.java
@@ -1,0 +1,15 @@
+package mc.monacotelecom.tecrep.equipments.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class BulkStandardLoadItemsResponse {
+    private BulkResultSummary summary;
+    private List<BulkItemResult> results;
+}

--- a/tecrep-equipments-management-dto/src/main/java/mc/monacotelecom/tecrep/equipments/dto/StandardLoadItemDTO.java
+++ b/tecrep-equipments-management-dto/src/main/java/mc/monacotelecom/tecrep/equipments/dto/StandardLoadItemDTO.java
@@ -1,0 +1,36 @@
+package mc.monacotelecom.tecrep.equipments.dto;
+
+import lombok.Data;
+import mc.monacotelecom.tecrep.equipments.annotations.ExactlyOneType;
+
+import javax.validation.constraints.Min;
+import javax.validation.constraints.NotNull;
+import javax.validation.constraints.AssertTrue;
+
+@Data
+@ExactlyOneType
+public class StandardLoadItemDTO {
+
+    @NotNull
+    private Long idStandard;
+
+    private Long idModel;
+    private Long idMaterial;
+    private Long idGroup;
+
+    @NotNull
+    @Min(0)
+    private Integer minQty;
+
+    @NotNull
+    @Min(0)
+    private Integer maxQty;
+
+    @AssertTrue(message = "maxQty must be greater than or equal to minQty")
+    public boolean isQuantityValid() {
+        if (minQty == null || maxQty == null) {
+            return true;
+        }
+        return maxQty >= minQty;
+    }
+}

--- a/tecrep-equipments-management-process/pom.xml
+++ b/tecrep-equipments-management-process/pom.xml
@@ -118,6 +118,10 @@
             <artifactId>spring-integration-jpa</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-jdbc</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.springframework.hateoas</groupId>
             <artifactId>spring-hateoas</artifactId>
         </dependency>

--- a/tecrep-equipments-management-process/src/main/java/mc/monacotelecom/tecrep/equipments/process/repository/StandardLoadItemRepository.java
+++ b/tecrep-equipments-management-process/src/main/java/mc/monacotelecom/tecrep/equipments/process/repository/StandardLoadItemRepository.java
@@ -1,0 +1,78 @@
+package mc.monacotelecom.tecrep.equipments.process.repository;
+
+import mc.monacotelecom.tecrep.equipments.dto.StandardLoadItemDTO;
+import org.springframework.jdbc.core.BatchPreparedStatementSetter;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.stereotype.Repository;
+
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+import java.util.List;
+
+@Repository
+public class StandardLoadItemRepository {
+
+    private static final String INSERT_MODEL_SQL = "INSERT INTO standard_load_equipmentmodel (id_standard, id_model, min_qty, max_qty, created_at) VALUES (?, ?, ?, ?, NOW()) ON DUPLICATE KEY UPDATE min_qty = VALUES(min_qty), max_qty = VALUES(max_qty)";
+    private static final String INSERT_MATERIAL_SQL = "INSERT INTO standard_load_equipmentmaterial (id_standard, id_material, min_qty, max_qty, created_at) VALUES (?, ?, ?, ?, NOW()) ON DUPLICATE KEY UPDATE min_qty = VALUES(min_qty), max_qty = VALUES(max_qty)";
+    private static final String INSERT_GROUP_SQL = "INSERT INTO standard_load_equipmentgroups (id_standard, id_group, min_qty, max_qty, created_at) VALUES (?, ?, ?, ?, NOW()) ON DUPLICATE KEY UPDATE min_qty = VALUES(min_qty), max_qty = VALUES(max_qty)";
+
+    private final JdbcTemplate jdbcTemplate;
+
+    public StandardLoadItemRepository(JdbcTemplate jdbcTemplate) {
+        this.jdbcTemplate = jdbcTemplate;
+    }
+
+    public int[] upsertModels(List<StandardLoadItemDTO> items) {
+        return jdbcTemplate.batchUpdate(INSERT_MODEL_SQL, new BatchPreparedStatementSetter() {
+            @Override
+            public void setValues(PreparedStatement ps, int i) throws SQLException {
+                StandardLoadItemDTO item = items.get(i);
+                ps.setLong(1, item.getIdStandard());
+                ps.setLong(2, item.getIdModel());
+                ps.setInt(3, item.getMinQty());
+                ps.setInt(4, item.getMaxQty());
+            }
+
+            @Override
+            public int getBatchSize() {
+                return items.size();
+            }
+        });
+    }
+
+    public int[] upsertMaterials(List<StandardLoadItemDTO> items) {
+        return jdbcTemplate.batchUpdate(INSERT_MATERIAL_SQL, new BatchPreparedStatementSetter() {
+            @Override
+            public void setValues(PreparedStatement ps, int i) throws SQLException {
+                StandardLoadItemDTO item = items.get(i);
+                ps.setLong(1, item.getIdStandard());
+                ps.setLong(2, item.getIdMaterial());
+                ps.setInt(3, item.getMinQty());
+                ps.setInt(4, item.getMaxQty());
+            }
+
+            @Override
+            public int getBatchSize() {
+                return items.size();
+            }
+        });
+    }
+
+    public int[] upsertGroups(List<StandardLoadItemDTO> items) {
+        return jdbcTemplate.batchUpdate(INSERT_GROUP_SQL, new BatchPreparedStatementSetter() {
+            @Override
+            public void setValues(PreparedStatement ps, int i) throws SQLException {
+                StandardLoadItemDTO item = items.get(i);
+                ps.setLong(1, item.getIdStandard());
+                ps.setLong(2, item.getIdGroup());
+                ps.setInt(3, item.getMinQty());
+                ps.setInt(4, item.getMaxQty());
+            }
+
+            @Override
+            public int getBatchSize() {
+                return items.size();
+            }
+        });
+    }
+}

--- a/tecrep-equipments-management-service/src/main/java/mc/monacotelecom/tecrep/equipments/service/StandardLoadItemBulkService.java
+++ b/tecrep-equipments-management-service/src/main/java/mc/monacotelecom/tecrep/equipments/service/StandardLoadItemBulkService.java
@@ -1,0 +1,160 @@
+package mc.monacotelecom.tecrep.equipments.service;
+
+import lombok.RequiredArgsConstructor;
+import mc.monacotelecom.tecrep.equipments.dto.*;
+import mc.monacotelecom.tecrep.equipments.process.repository.StandardLoadItemRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import javax.validation.ConstraintViolation;
+import javax.validation.Validator;
+import java.util.*;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class StandardLoadItemBulkService {
+
+    private final Validator validator;
+    private final StandardLoadItemRepository repository;
+
+    @Transactional
+    public BulkStandardLoadItemsResponse upsertItems(BulkStandardLoadItemsRequest request) {
+        List<StandardLoadItemDTO> items = Optional.ofNullable(request.getItems()).orElse(Collections.emptyList());
+        List<BulkItemResult> results = new ArrayList<>(Collections.nCopies(items.size(), null));
+        int skipped = 0;
+        int validationErrors = 0;
+
+        Map<String, ItemWrapper> unique = new LinkedHashMap<>();
+
+        for (int i = 0; i < items.size(); i++) {
+            StandardLoadItemDTO item = items.get(i);
+            Set<ConstraintViolation<StandardLoadItemDTO>> violations = validator.validate(item);
+            String target = resolveTarget(item);
+            Map<String, Long> keyMap = buildKey(item);
+            if (!violations.isEmpty()) {
+                String message = violations.stream().map(ConstraintViolation::getMessage).collect(Collectors.joining(", "));
+                results.set(i, new BulkItemResult(i, target, keyMap, "validation-error", message));
+                validationErrors++;
+                continue;
+            }
+            String dedupKey = generateKey(item, target);
+            ItemWrapper previous = unique.put(dedupKey, new ItemWrapper(item, i, target, keyMap));
+            if (previous != null) {
+                results.set(previous.index, new BulkItemResult(previous.index, previous.target, previous.keyMap, "skipped-duplicate-in-payload", null));
+                skipped++;
+            }
+        }
+
+        List<ItemWrapper> models = new ArrayList<>();
+        List<ItemWrapper> materials = new ArrayList<>();
+        List<ItemWrapper> groups = new ArrayList<>();
+        unique.values().forEach(w -> {
+            if (w.item.getIdModel() != null) {
+                models.add(w);
+            } else if (w.item.getIdMaterial() != null) {
+                materials.add(w);
+            } else {
+                groups.add(w);
+            }
+        });
+
+        int inserted = 0;
+        int updated = 0;
+
+        if (!models.isEmpty()) {
+            int[] counts = repository.upsertModels(models.stream().map(w -> w.item).collect(Collectors.toList()));
+            for (int j = 0; j < models.size(); j++) {
+                ItemWrapper w = models.get(j);
+                int count = counts[j];
+                if (count == 1) {
+                    inserted++;
+                } else if (count == 2) {
+                    updated++;
+                }
+                results.set(w.index, new BulkItemResult(w.index, w.target, w.keyMap, "upserted", null));
+            }
+        }
+
+        if (!materials.isEmpty()) {
+            int[] counts = repository.upsertMaterials(materials.stream().map(w -> w.item).collect(Collectors.toList()));
+            for (int j = 0; j < materials.size(); j++) {
+                ItemWrapper w = materials.get(j);
+                int count = counts[j];
+                if (count == 1) {
+                    inserted++;
+                } else if (count == 2) {
+                    updated++;
+                }
+                results.set(w.index, new BulkItemResult(w.index, w.target, w.keyMap, "upserted", null));
+            }
+        }
+
+        if (!groups.isEmpty()) {
+            int[] counts = repository.upsertGroups(groups.stream().map(w -> w.item).collect(Collectors.toList()));
+            for (int j = 0; j < groups.size(); j++) {
+                ItemWrapper w = groups.get(j);
+                int count = counts[j];
+                if (count == 1) {
+                    inserted++;
+                } else if (count == 2) {
+                    updated++;
+                }
+                results.set(w.index, new BulkItemResult(w.index, w.target, w.keyMap, "upserted", null));
+            }
+        }
+
+        BulkResultSummary summary = new BulkResultSummary(inserted, updated, skipped, validationErrors);
+        return new BulkStandardLoadItemsResponse(summary, results);
+    }
+
+    private String resolveTarget(StandardLoadItemDTO item) {
+        if (item.getIdModel() != null) {
+            return "equipmentmodel";
+        } else if (item.getIdMaterial() != null) {
+            return "equipmentmaterial";
+        } else if (item.getIdGroup() != null) {
+            return "equipmentgroups";
+        } else {
+            return "unknown";
+        }
+    }
+
+    private Map<String, Long> buildKey(StandardLoadItemDTO item) {
+        Map<String, Long> map = new LinkedHashMap<>();
+        map.put("idStandard", item.getIdStandard());
+        if (item.getIdModel() != null) {
+            map.put("idModel", item.getIdModel());
+        } else if (item.getIdMaterial() != null) {
+            map.put("idMaterial", item.getIdMaterial());
+        } else if (item.getIdGroup() != null) {
+            map.put("idGroup", item.getIdGroup());
+        }
+        return map;
+    }
+
+    private String generateKey(StandardLoadItemDTO item, String target) {
+        Long specificId = item.getIdModel();
+        if (specificId == null) {
+            specificId = item.getIdMaterial();
+        }
+        if (specificId == null) {
+            specificId = item.getIdGroup();
+        }
+        return target + ':' + item.getIdStandard() + ':' + specificId;
+    }
+
+    private static class ItemWrapper {
+        private final StandardLoadItemDTO item;
+        private final int index;
+        private final String target;
+        private final Map<String, Long> keyMap;
+
+        private ItemWrapper(StandardLoadItemDTO item, int index, String target, Map<String, Long> keyMap) {
+            this.item = item;
+            this.index = index;
+            this.target = target;
+            this.keyMap = keyMap;
+        }
+    }
+}

--- a/tecrep-equipments-management-webservice/src/main/java/mc/monacotelecom/tecrep/equipments/controller/StandardLoadItemController.java
+++ b/tecrep-equipments-management-webservice/src/main/java/mc/monacotelecom/tecrep/equipments/controller/StandardLoadItemController.java
@@ -1,0 +1,23 @@
+package mc.monacotelecom.tecrep.equipments.controller;
+
+import lombok.RequiredArgsConstructor;
+import mc.monacotelecom.tecrep.equipments.dto.BulkStandardLoadItemsRequest;
+import mc.monacotelecom.tecrep.equipments.dto.BulkStandardLoadItemsResponse;
+import mc.monacotelecom.tecrep.equipments.service.StandardLoadItemBulkService;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RequiredArgsConstructor
+@RestController
+@RequestMapping("api/v1/standard-load/items")
+public class StandardLoadItemController {
+
+    private final StandardLoadItemBulkService service;
+
+    @PostMapping
+    public BulkStandardLoadItemsResponse upsert(@RequestBody BulkStandardLoadItemsRequest request) {
+        return service.upsertItems(request);
+    }
+}


### PR DESCRIPTION
## Summary
- add DTOs and validation for standard load bulk items
- implement service and repository to batch upsert models, materials and groups
- expose POST /api/v1/standard-load/items endpoint

## Testing
- `mvn -q -pl tecrep-equipments-management-dto,tecrep-equipments-management-process,tecrep-equipments-management-service,tecrep-equipments-management-webservice -am test` *(fails: Could not resolve parent POM - Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a8c214f4ac8323ac619f5c0d0aacbe