### PR TITLE
feat: add standard load items query endpoint

### DIFF
--- a/tecrep-equipments-management-domain/src/main/java/mc/monacotelecom/tecrep/equipments/repository/StandardLoadItemsQueryRepository.java
+++ b/tecrep-equipments-management-domain/src/main/java/mc/monacotelecom/tecrep/equipments/repository/StandardLoadItemsQueryRepository.java
@@ -1,0 +1,96 @@
+package mc.monacotelecom.tecrep.equipments.repository;
+
+import mc.monacotelecom.tecrep.equipments.dto.GroupItem;
+import mc.monacotelecom.tecrep.equipments.dto.MaterialItem;
+import mc.monacotelecom.tecrep.equipments.dto.ModelItem;
+import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
+import org.springframework.jdbc.core.RowMapper;
+import org.springframework.stereotype.Repository;
+import org.springframework.dao.EmptyResultDataAccessException;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.List;
+import java.util.Map;
+
+@Repository
+public class StandardLoadItemsQueryRepository {
+
+    private static final String SQL_EXIST = "SELECT 1 FROM standard_load WHERE id = :idStandard";
+
+    private static final String SQL_MODEL = "SELECT slem.id, slem.id_standard, slem.id_model, slem.min_qty, slem.max_qty, slem.created_at, em.name AS model_name " +
+            "FROM standard_load_equipmentmodel slem JOIN equipment_model em ON em.id = slem.id_model " +
+            "WHERE slem.id_standard = :idStandard ORDER BY em.name";
+
+    private static final String SQL_MATERIAL = "SELECT slemat.id, slemat.id_standard, slemat.id_material, slemat.min_qty, slemat.max_qty, slemat.created_at, m.name AS material_name " +
+            "FROM standard_load_equipmentmaterial slemat JOIN materials m ON m.id = slemat.id_material " +
+            "WHERE slemat.id_standard = :idStandard ORDER BY m.name";
+
+    private static final String SQL_GROUP = "SELECT sleg.id, sleg.id_standard, sleg.id_group, sleg.min_qty, sleg.max_qty, sleg.created_at, g.name AS group_name " +
+            "FROM standard_load_equipmentgroups sleg JOIN equipment_groups g ON g.id = sleg.id_group " +
+            "WHERE sleg.id_standard = :idStandard ORDER BY g.name";
+
+    private final NamedParameterJdbcTemplate jdbcTemplate;
+
+    public StandardLoadItemsQueryRepository(NamedParameterJdbcTemplate jdbcTemplate) {
+        this.jdbcTemplate = jdbcTemplate;
+    }
+
+    public boolean existsStandard(long idStandard) {
+        try {
+            jdbcTemplate.queryForObject(SQL_EXIST, Map.of("idStandard", idStandard), Integer.class);
+            return true;
+        } catch (EmptyResultDataAccessException e) {
+            return false;
+        }
+    }
+
+    public List<ModelItem> findModels(long idStandard) {
+        return jdbcTemplate.query(SQL_MODEL, new MapSqlParameterSource("idStandard", idStandard), new RowMapper<ModelItem>() {
+            @Override
+            public ModelItem mapRow(ResultSet rs, int rowNum) throws SQLException {
+                return new ModelItem(
+                        rs.getLong("id"),
+                        rs.getLong("id_model"),
+                        rs.getInt("min_qty"),
+                        rs.getInt("max_qty"),
+                        rs.getTimestamp("created_at").toInstant(),
+                        rs.getString("model_name")
+                );
+            }
+        });
+    }
+
+    public List<MaterialItem> findMaterials(long idStandard) {
+        return jdbcTemplate.query(SQL_MATERIAL, new MapSqlParameterSource("idStandard", idStandard), new RowMapper<MaterialItem>() {
+            @Override
+            public MaterialItem mapRow(ResultSet rs, int rowNum) throws SQLException {
+                return new MaterialItem(
+                        rs.getLong("id"),
+                        rs.getLong("id_material"),
+                        rs.getInt("min_qty"),
+                        rs.getInt("max_qty"),
+                        rs.getTimestamp("created_at").toInstant(),
+                        rs.getString("material_name")
+                );
+            }
+        });
+    }
+
+    public List<GroupItem> findGroups(long idStandard) {
+        return jdbcTemplate.query(SQL_GROUP, new MapSqlParameterSource("idStandard", idStandard), new RowMapper<GroupItem>() {
+            @Override
+            public GroupItem mapRow(ResultSet rs, int rowNum) throws SQLException {
+                return new GroupItem(
+                        rs.getLong("id"),
+                        rs.getLong("id_group"),
+                        rs.getInt("min_qty"),
+                        rs.getInt("max_qty"),
+                        rs.getTimestamp("created_at").toInstant(),
+                        rs.getString("group_name")
+                );
+            }
+        });
+    }
+}

--- a/tecrep-equipments-management-dto/src/main/java/mc/monacotelecom/tecrep/equipments/dto/Counts.java
+++ b/tecrep-equipments-management-dto/src/main/java/mc/monacotelecom/tecrep/equipments/dto/Counts.java
@@ -1,0 +1,14 @@
+package mc.monacotelecom.tecrep.equipments.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class Counts {
+    private int model;
+    private int material;
+    private int group;
+}

--- a/tecrep-equipments-management-dto/src/main/java/mc/monacotelecom/tecrep/equipments/dto/GroupItem.java
+++ b/tecrep-equipments-management-dto/src/main/java/mc/monacotelecom/tecrep/equipments/dto/GroupItem.java
@@ -1,0 +1,19 @@
+package mc.monacotelecom.tecrep.equipments.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.Instant;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class GroupItem {
+    private Long id;
+    private Long idGroup;
+    private Integer minQty;
+    private Integer maxQty;
+    private Instant createdAt;
+    private String groupName;
+}

--- a/tecrep-equipments-management-dto/src/main/java/mc/monacotelecom/tecrep/equipments/dto/MaterialItem.java
+++ b/tecrep-equipments-management-dto/src/main/java/mc/monacotelecom/tecrep/equipments/dto/MaterialItem.java
@@ -1,0 +1,19 @@
+package mc.monacotelecom.tecrep.equipments.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.Instant;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class MaterialItem {
+    private Long id;
+    private Long idMaterial;
+    private Integer minQty;
+    private Integer maxQty;
+    private Instant createdAt;
+    private String materialName;
+}

--- a/tecrep-equipments-management-dto/src/main/java/mc/monacotelecom/tecrep/equipments/dto/ModelItem.java
+++ b/tecrep-equipments-management-dto/src/main/java/mc/monacotelecom/tecrep/equipments/dto/ModelItem.java
@@ -1,0 +1,19 @@
+package mc.monacotelecom.tecrep.equipments.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.Instant;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class ModelItem {
+    private Long id;
+    private Long idModel;
+    private Integer minQty;
+    private Integer maxQty;
+    private Instant createdAt;
+    private String modelName;
+}

--- a/tecrep-equipments-management-dto/src/main/java/mc/monacotelecom/tecrep/equipments/dto/StandardLoadItemsResponse.java
+++ b/tecrep-equipments-management-dto/src/main/java/mc/monacotelecom/tecrep/equipments/dto/StandardLoadItemsResponse.java
@@ -1,0 +1,18 @@
+package mc.monacotelecom.tecrep.equipments.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class StandardLoadItemsResponse {
+    private Long standardId;
+    private List<ModelItem> model;
+    private List<MaterialItem> material;
+    private List<GroupItem> group;
+    private Counts counts;
+}

--- a/tecrep-equipments-management-service/src/main/java/mc/monacotelecom/tecrep/equipments/exception/StandardLoadNotFoundException.java
+++ b/tecrep-equipments-management-service/src/main/java/mc/monacotelecom/tecrep/equipments/exception/StandardLoadNotFoundException.java
@@ -1,0 +1,14 @@
+package mc.monacotelecom.tecrep.equipments.exception;
+
+public class StandardLoadNotFoundException extends RuntimeException {
+    private final Long idStandard;
+
+    public StandardLoadNotFoundException(Long idStandard) {
+        super("standard_load id not found");
+        this.idStandard = idStandard;
+    }
+
+    public Long getIdStandard() {
+        return idStandard;
+    }
+}

--- a/tecrep-equipments-management-service/src/main/java/mc/monacotelecom/tecrep/equipments/service/StandardLoadQueryService.java
+++ b/tecrep-equipments-management-service/src/main/java/mc/monacotelecom/tecrep/equipments/service/StandardLoadQueryService.java
@@ -1,0 +1,38 @@
+package mc.monacotelecom.tecrep.equipments.service;
+
+import lombok.RequiredArgsConstructor;
+import mc.monacotelecom.tecrep.equipments.dto.*;
+import mc.monacotelecom.tecrep.equipments.exception.StandardLoadNotFoundException;
+import mc.monacotelecom.tecrep.equipments.repository.StandardLoadItemsQueryRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Collections;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class StandardLoadQueryService {
+
+    private final StandardLoadItemsQueryRepository repository;
+
+    @Transactional(readOnly = true)
+    public StandardLoadItemsResponse getItemsByStandard(Long idStandard) {
+        if (!repository.existsStandard(idStandard)) {
+            throw new StandardLoadNotFoundException(idStandard);
+        }
+        List<ModelItem> models = repository.findModels(idStandard);
+        List<MaterialItem> materials = repository.findMaterials(idStandard);
+        List<GroupItem> groups = repository.findGroups(idStandard);
+
+        Counts counts = new Counts(models.size(), materials.size(), groups.size());
+
+        return new StandardLoadItemsResponse(
+                idStandard,
+                models != null ? models : Collections.emptyList(),
+                materials != null ? materials : Collections.emptyList(),
+                groups != null ? groups : Collections.emptyList(),
+                counts
+        );
+    }
+}

--- a/tecrep-equipments-management-webservice/src/main/java/mc/monacotelecom/tecrep/equipments/controller/StandardLoadQueryController.java
+++ b/tecrep-equipments-management-webservice/src/main/java/mc/monacotelecom/tecrep/equipments/controller/StandardLoadQueryController.java
@@ -1,0 +1,20 @@
+package mc.monacotelecom.tecrep.equipments.controller;
+
+import lombok.RequiredArgsConstructor;
+import mc.monacotelecom.tecrep.equipments.dto.StandardLoadItemsResponse;
+import mc.monacotelecom.tecrep.equipments.service.StandardLoadQueryService;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+public class StandardLoadQueryController {
+
+    private final StandardLoadQueryService service;
+
+    @GetMapping("/api/v1/standard-load/{idStandard}/items")
+    public StandardLoadItemsResponse getItems(@PathVariable Long idStandard) {
+        return service.getItemsByStandard(idStandard);
+    }
+}

--- a/tecrep-equipments-management-webservice/src/main/java/mc/monacotelecom/tecrep/equipments/exception/StandardLoadQueryExceptionHandler.java
+++ b/tecrep-equipments-management-webservice/src/main/java/mc/monacotelecom/tecrep/equipments/exception/StandardLoadQueryExceptionHandler.java
@@ -1,0 +1,31 @@
+package mc.monacotelecom.tecrep.equipments.exception;
+
+import mc.monacotelecom.tecrep.equipments.controller.StandardLoadQueryController;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@RestControllerAdvice(assignableTypes = StandardLoadQueryController.class)
+public class StandardLoadQueryExceptionHandler {
+
+    @ExceptionHandler(StandardLoadNotFoundException.class)
+    @ResponseStatus(HttpStatus.NOT_FOUND)
+    public Map<String, Object> handleNotFound(StandardLoadNotFoundException ex) {
+        Map<String, Object> body = new HashMap<>();
+        body.put("message", ex.getMessage());
+        body.put("idStandard", ex.getIdStandard());
+        return body;
+    }
+
+    @ExceptionHandler(Exception.class)
+    @ResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR)
+    public Map<String, Object> handleGeneric(Exception ex) {
+        Map<String, Object> body = new HashMap<>();
+        body.put("message", "internal server error");
+        return body;
+    }
+}


### PR DESCRIPTION
## Summary
- add DTOs for standard load item queries
- implement JDBC repository and service to fetch model/material/group items
- expose GET `/api/v1/standard-load/{idStandard}/items` with custom error handling

## Testing
- `mvn -q -pl tecrep-equipments-management-webservice -am test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_68a8d621da3083238cc3029c4e4438af